### PR TITLE
Add start/stop hotkey for tasks

### DIFF
--- a/src/task_tui/app.py
+++ b/src/task_tui/app.py
@@ -161,6 +161,7 @@ class TaskTuiApp(App):
         Binding("d", "set_done", "Set done"),
         Binding("a", "add_task", "Add task"),
         Binding("r", "refresh_tasks", "Refresh"),
+        Binding("s", "toggle_start_stop", "Start/stop"),
     ]
 
     def __init__(self, report: str) -> None:
@@ -274,3 +275,18 @@ class TaskTuiApp(App):
         current_task = self.tasks[table.cursor_row]
         confirm_done_scree = ConfirmDialog(f'Are you sure you want set task "{current_task.description}" ({current_task.id}) to done?')
         self.push_screen(confirm_done_scree, set_done)
+
+    def action_toggle_start_stop(self) -> None:
+        table = self.query_one(TaskReport)
+        if len(self.tasks) == 0:
+            return
+
+        current_task = self.tasks[table.cursor_row]
+        if current_task.start is None:
+            task_cli.start_task(current_task)
+            self.notify(f'Task "{current_task.description}" started')
+        else:
+            task_cli.stop_task(current_task)
+            self.notify(f'Task "{current_task.description}" stopped')
+
+        self.post_message(TasksChanged(select_task_id=current_task.id))

--- a/src/task_tui/task_cli.py
+++ b/src/task_tui/task_cli.py
@@ -64,6 +64,14 @@ class TaskCli:
         log.info("Setting task %s to done", task.id)
         self._run_task(str(task.uuid), "done")
 
+    def start_task(self, task: Task) -> None:
+        log.info("Starting task %s", task.id)
+        self._run_task(str(task.uuid), "start")
+
+    def stop_task(self, task: Task) -> None:
+        log.info("Stopping task %s", task.id)
+        self._run_task(str(task.uuid), "stop")
+
     def add_task(self, description: str) -> int:
         log.info("Adding task with description %s", description)
         # split so that description isn't passed as one complete string (which would not allow to add prio/proj/etc.)

--- a/tests/test_task_cli.py
+++ b/tests/test_task_cli.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from task_tui.data_models import Status, Task
+from task_tui.task_cli import TaskCli
+
+
+def _make_task(start: datetime | None = None) -> Task:
+    now = datetime(2024, 1, 1, 0, 0, 0)
+    return Task(
+        id=1,
+        description="task",
+        entry=now.isoformat(),
+        modified=now.isoformat(),
+        due=None,
+        start=start.isoformat() if start else None,
+        scheduled=None,
+        wait=None,
+        end=None,
+        until=None,
+        recur=None,
+        project=None,
+        status=Status.PENDING,
+        uuid=uuid4(),
+        urgency=0.0,
+        annotations=[],
+        priority=None,
+        tags=set(),
+        depends=set(),
+        virtual_tags=set(),
+    )
+
+
+def test_start_task_uses_task_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(self: TaskCli, *args: str) -> SimpleNamespace:
+        calls.append(args)
+        return SimpleNamespace(stdout="", returncode=0)
+
+    monkeypatch.setattr(TaskCli, "_run_task", fake_run, raising=False)
+    cli = TaskCli()
+    task = _make_task()
+
+    cli.start_task(task)
+
+    assert calls[0] == ("show",)
+    assert calls[1] == (str(task.uuid), "start")
+
+
+def test_stop_task_uses_task_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(self: TaskCli, *args: str) -> SimpleNamespace:
+        calls.append(args)
+        return SimpleNamespace(stdout="", returncode=0)
+
+    monkeypatch.setattr(TaskCli, "_run_task", fake_run, raising=False)
+    cli = TaskCli()
+    task = _make_task(start=datetime(2024, 1, 1, 12, 0, 0))
+
+    cli.stop_task(task)
+
+    assert calls[0] == ("show",)
+    assert calls[1] == (str(task.uuid), "stop")


### PR DESCRIPTION
## Summary
- add an `s` binding that starts or stops the selected task and refreshes the report selection
- add TaskCli helpers to issue `start` and `stop` commands
- add TaskCli tests that verify the correct task CLI invocations

## Testing
- uv run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237140f160832d9cdff43e4ed721c2)